### PR TITLE
1st draft alternative to UUID password "base"

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -8,5 +8,3 @@
 module github.com/atc0005/tsm-pass
 
 go 1.14
-
-require github.com/google/uuid v1.1.2

--- a/go.sum
+++ b/go.sum
@@ -1,2 +1,0 @@
-github.com/google/uuid v1.1.2 h1:EVhdT+1Kseyi1/pUmXKaFxYsDNy9RQYkMWRH68J/W7Y=
-github.com/google/uuid v1.1.2/go.mod h1:TIyPZe4MgqvfeYDBFedMoGGpEw/LqOeaOT+nhxU+yHo=


### PR DESCRIPTION
Create "character map" of valid TSM password characters
and pick one character from this map per loop iteration.
Set start/end points for loop iteration based on specified
password length.

Use separate extendCharMap and newTSMCharMap functions
to drive bulk of logic, leaving generatePassword to looping
and password string accumulation.

The end result is a sharp visual difference from the previous
Go-based draft.

refs GH-2