### PR TITLE
Replace (potential) leading dash with underscore

### DIFF
--- a/cmd/tsm-pass/main.go
+++ b/cmd/tsm-pass/main.go
@@ -120,6 +120,11 @@ func generatePassword(length int, reqNums int, reqSpecialChars int) (string, err
 		password[i], password[j] = password[j], password[i]
 	})
 
+	// if password has leading dash, replace with underscore (GH-15)
+	if password[0] == '-' {
+		password[0] = '_'
+	}
+
 	return string(password), nil
 
 }


### PR DESCRIPTION
As noted elsewhere, I am not sure whether my old notes
indicated this change was needed to fix an actual problem
or guard against a hypothetical issue that could occur
when resetting the default password to the new one (e.g.,
shell interpolation of special chars).

Making the change for the Go implementation on the off-chance
that this is a real problem.

fixes GH-15