### PR TITLE
Add flags for min digits, specials, total chars

### DIFF
--- a/internal/config/config.go
+++ b/internal/config/config.go
@@ -1,0 +1,125 @@
+// Copyright 2020 Adam Chalkley
+//
+// https://github.com/atc0005/tsm-pass
+//
+// Licensed under the MIT License. See LICENSE file in the project root for
+// full license information.
+
+package config
+
+import (
+	"flag"
+	"fmt"
+	"os"
+)
+
+// Updated via Makefile builds. Setting placeholder value here so that
+// something resembling a version string will be provided for non-Makefile
+// builds.
+var version string = "x.y.z"
+
+const myAppName string = "tsm-pass"
+const myAppURL string = "https://github.com/atc0005/tsm-pass"
+
+const (
+	versionFlagHelp         string = "Whether to display application version and then immediately exit application."
+	minDigitsFlagHelp       string = "The minimum number of digits that will be used when generating a new TSM-compatible password."
+	minSpecialCharsFlagHelp string = "The minimum number of (compatible) special characters that will be used when generating a new TSM-compatible password."
+	totalCharsFlagHelp      string = "The total number of characters to use when generating a new TSM-compatible password."
+)
+
+// Default flag settings if not overridden by user input
+const (
+	defaultMinDigits             int  = 10
+	defaultMinSpecialChars       int  = 25
+	defaultTotalChars            int  = 63
+	defaultDisplayVersionAndExit bool = false
+)
+
+// Config represents the application configuration as specified via
+// command-line flags.
+type Config struct {
+
+	// The minimum number of digits that will be used when generating a new
+	// TSM-compatible password.
+	minDigits int
+
+	// The minimum number of (compatible) special characters that will be used
+	// when generating a new TSM-compatible password.
+	minSpecialChars int
+
+	// The total number of characters to use when generating a new
+	// TSM-compatible password.
+	totalChars int
+
+	// showVersion is a flag indicating whether the user opted to display only
+	// the version string and then immediately exit the application
+	showVersion bool
+}
+
+// Usage is a custom override for the default Help text provided by the flag
+// package. Here we prepend some additional metadata to the existing output.
+var Usage = func() {
+	fmt.Fprintln(flag.CommandLine.Output(), "\n"+Version()+"\n")
+	fmt.Fprintf(flag.CommandLine.Output(), "Usage of %s:\n", os.Args[0])
+	flag.PrintDefaults()
+}
+
+// Version emits application name, version and repo location.
+func Version() string {
+	return fmt.Sprintf("%s %s (%s)", myAppName, version, myAppURL)
+}
+
+// New is a factory function for instantiating new application configurations.
+// This function handles processing flag values, including validation of
+// provided values.
+func New() (*Config, error) {
+
+	var config Config
+
+	config.handleFlagsConfig()
+
+	// Return immediately if user just wants version details
+	if config.ShowVersion() {
+		return &config, nil
+	}
+
+	if err := config.validate(); err != nil {
+		return nil, err
+	}
+
+	return &config, nil
+
+}
+
+// validate verifies all Config struct fields have been provided acceptable
+// values.
+func (c Config) validate() error {
+
+	if c.PassMinDigits()+c.PassMinSpecialChars() > c.PassTotalChars() {
+		return fmt.Errorf(
+			"min digits (%d) + min special chars (%d): %d chars; "+
+				"required chars greater than total chars limit (%d)",
+			c.PassMinDigits(),
+			c.PassMinSpecialChars(),
+			c.PassMinDigits()+c.PassMinSpecialChars(),
+			c.totalChars,
+		)
+	}
+
+	if c.PassTotalChars() > defaultTotalChars {
+		fmt.Printf(
+			"\nWARNING: Password length of %d requested.\n"+
+				"TSM limits the total password length "+
+				"to %d characters by default.\n"+
+				"Check with your TSM server admins for the current "+
+				"maximum password length.\n\n",
+			c.PassTotalChars(),
+			defaultTotalChars,
+		)
+	}
+
+	// Optimist
+	return nil
+
+}

--- a/internal/config/doc.go
+++ b/internal/config/doc.go
@@ -1,0 +1,10 @@
+// Copyright 2020 Adam Chalkley
+//
+// https://github.com/atc0005/tsm-pass
+//
+// Licensed under the MIT License. See LICENSE file in the project root for
+// full license information.
+
+// Package config provides types and functions to collect, validate and apply
+// user-provided settings.
+package config

--- a/internal/config/flags.go
+++ b/internal/config/flags.go
@@ -1,0 +1,32 @@
+// Copyright 2020 Adam Chalkley
+//
+// https://github.com/atc0005/tsm-pass
+//
+// Licensed under the MIT License. See LICENSE file in the project root for
+// full license information.
+
+package config
+
+import "flag"
+
+func (c *Config) handleFlagsConfig() {
+
+	flag.BoolVar(&c.showVersion, "v", defaultDisplayVersionAndExit, versionFlagHelp+" (shorthand)")
+	flag.BoolVar(&c.showVersion, "version", defaultDisplayVersionAndExit, versionFlagHelp)
+
+	flag.IntVar(&c.minDigits, "md", defaultMinDigits, minDigitsFlagHelp+" (shorthand)")
+	flag.IntVar(&c.minDigits, "min-digits", defaultMinDigits, minDigitsFlagHelp)
+
+	flag.IntVar(&c.minSpecialChars, "ms", defaultMinSpecialChars, minSpecialCharsFlagHelp+" (shorthand)")
+	flag.IntVar(&c.minSpecialChars, "min-specials", defaultMinSpecialChars, minSpecialCharsFlagHelp)
+
+	flag.IntVar(&c.totalChars, "l", defaultTotalChars, totalCharsFlagHelp+" (shorthand)")
+	flag.IntVar(&c.totalChars, "length", defaultTotalChars, totalCharsFlagHelp)
+
+	// Allow our function to override the default Help output
+	flag.Usage = Usage
+
+	// parse flag definitions from the argument list
+	flag.Parse()
+
+}

--- a/internal/config/getters.go
+++ b/internal/config/getters.go
@@ -1,0 +1,33 @@
+// Copyright 2020 Adam Chalkley
+//
+// https://github.com/atc0005/tsm-pass
+//
+// Licensed under the MIT License. See LICENSE file in the project root for
+// full license information.
+
+package config
+
+// ShowVersion returns the user-provided choice of displaying the application
+// version and exiting or the default value for this choice.
+func (c Config) ShowVersion() bool {
+	return c.showVersion
+}
+
+// PassMinDigits returns the user-specified number of minimum digits to be
+// used in the generated password, or the default value if not provided.
+func (c Config) PassMinDigits() int {
+	return c.minDigits
+}
+
+// PassMinSpecialChars returns the user-specified number of minimum special
+// characters to be used in the generated password, or the default value if
+// not provided.
+func (c Config) PassMinSpecialChars() int {
+	return c.minSpecialChars
+}
+
+// PassTotalChars returns the user-specified total number of characters to be
+// used in the generated password, or the default value if not provided.
+func (c Config) PassTotalChars() int {
+	return c.totalChars
+}


### PR DESCRIPTION
Use standard library `flag` package, borrow structure from `atc0005/dnsc` and `atc0005/check-cert` projects for simplicity.

fixes GH-19