### PR TITLE
Update cfg init to use custom error, minor cleanup

### DIFF
--- a/cmd/tsm-pass/main.go
+++ b/cmd/tsm-pass/main.go
@@ -98,33 +98,28 @@ func generatePassword(length int, reqNums int, reqSpecialChars int) (string, err
 
 func main() {
 
-	cfg, err := config.New()
+	cfg, cfgErr := config.New()
 	switch {
-	// TODO: How else to guard against nil cfg object?
-	case cfg != nil && cfg.ShowVersion():
+	case errors.Is(cfgErr, config.ErrVersionRequested):
 		fmt.Println(config.Version())
 		os.Exit(0)
-	case err == nil:
+	case cfgErr == nil:
 		// do nothing for this one
-	case errors.Is(err, flag.ErrHelp):
-		// workaround until Go 1.15 is our baseline
-		os.Exit(0)
 	default:
-		fmt.Printf("\nfailed to initialize application: %s\n", err)
+		fmt.Printf("\nfailed to initialize application: %s\n", cfgErr)
 		flag.Usage()
 		os.Exit(1)
 	}
 
-	passwd, err := generatePassword(
+	passwd, passwdErr := generatePassword(
 		cfg.PassTotalChars(),
 		cfg.PassMinDigits(),
 		cfg.PassMinSpecialChars(),
 	)
 
-	if err != nil {
-		panic(err)
+	if passwdErr != nil {
+		panic(passwdErr)
 	}
 
-	// TODO: Should we emit a newline here?
 	fmt.Println(passwd)
 }

--- a/internal/config/config.go
+++ b/internal/config/config.go
@@ -8,6 +8,7 @@
 package config
 
 import (
+	"errors"
 	"flag"
 	"fmt"
 	"os"
@@ -18,23 +19,9 @@ import (
 // builds.
 var version string = "x.y.z"
 
-const myAppName string = "tsm-pass"
-const myAppURL string = "https://github.com/atc0005/tsm-pass"
-
-const (
-	versionFlagHelp         string = "Whether to display application version and then immediately exit application."
-	minDigitsFlagHelp       string = "The minimum number of digits that will be used when generating a new TSM-compatible password."
-	minSpecialCharsFlagHelp string = "The minimum number of (compatible) special characters that will be used when generating a new TSM-compatible password."
-	totalCharsFlagHelp      string = "The total number of characters to use when generating a new TSM-compatible password. See Password Requirements in the README for more information."
-)
-
-// Default flag settings if not overridden by user input
-const (
-	defaultMinDigits             int  = 10
-	defaultMinSpecialChars       int  = 25
-	defaultTotalChars            int  = 63
-	defaultDisplayVersionAndExit bool = false
-)
+// ErrVersionRequested indicates that the user requested application version
+// information
+var ErrVersionRequested = errors.New("version information requested")
 
 // Config represents the application configuration as specified via
 // command-line flags.
@@ -81,7 +68,7 @@ func New() (*Config, error) {
 
 	// Return immediately if user just wants version details
 	if config.ShowVersion() {
-		return &config, nil
+		return nil, ErrVersionRequested
 	}
 
 	if err := config.validate(); err != nil {

--- a/internal/config/constants.go
+++ b/internal/config/constants.go
@@ -7,6 +7,28 @@
 
 package config
 
+// App specific shared values
+const (
+	myAppName string = "tsm-pass"
+	myAppURL  string = "https://github.com/atc0005/tsm-pass"
+)
+
+// Help text used with flags
+const (
+	versionFlagHelp         string = "Whether to display application version and then immediately exit application."
+	minDigitsFlagHelp       string = "The minimum number of digits that will be used when generating a new TSM-compatible password."
+	minSpecialCharsFlagHelp string = "The minimum number of (compatible) special characters that will be used when generating a new TSM-compatible password."
+	totalCharsFlagHelp      string = "The total number of characters to use when generating a new TSM-compatible password. See Password Requirements in the README for more information."
+)
+
+// Default flag settings if not overridden by user input
+const (
+	defaultMinDigits             int  = 10
+	defaultMinSpecialChars       int  = 25
+	defaultTotalChars            int  = 63
+	defaultDisplayVersionAndExit bool = false
+)
+
 // Shared, password related constants for easy access.
 // #nosec G101 (https://github.com/securego/gosec)
 const (


### PR DESCRIPTION
- Move other constants to dedicated file
- Remove flag.ErrHelp case since it isn't used/triggered
- Add config.ErrVersionRequested to provide a reliable
  way of determining whether the version flag was used
- Rename some error variables in an effort to prevent
  potential future shadowing