### PR TITLE
Fix/workaround linting errors

### DIFF
--- a/cmd/tsm-pass/main.go
+++ b/cmd/tsm-pass/main.go
@@ -9,7 +9,7 @@
 package main
 
 import (
-	"crypto/rand"
+	crand "crypto/rand"
 	"errors"
 	"flag"
 	"fmt"
@@ -47,7 +47,7 @@ func generatePassword(length int, reqNums int, reqSpecialChars int) (string, err
 	getByte := func(b []byte) (byte, error) {
 		maxRandNum := big.NewInt(int64(len(b)))
 
-		nBig, rngErr := rand.Int(rand.Reader, maxRandNum)
+		nBig, rngErr := crand.Int(crand.Reader, maxRandNum)
 		if rngErr != nil {
 			return 0, fmt.Errorf("unable to generate random number: %w", rngErr)
 		}

--- a/doc.go
+++ b/doc.go
@@ -6,33 +6,29 @@
 // full license information.
 
 /*
-
 Generate passwords compatible with Tivoli/TSM/Spectrum Protect.
 
-PROJECT HOME
+# PROJECT HOME
 
 See our GitHub repo (https://github.com/atc0005/tsm-pass) for the latest
 code, to file an issue or submit improvements for review and potential
 inclusion into the project.
 
-PURPOSE
+# PURPOSE
 
 This repo provides a Go CLI application that can be used to generate a
 password string compatible with IBM Spectrum Protect 6.3.3 or later. An older
 Python script previously used for this purpose is included for reference or
 alternative use.
 
-FEATURES
+# FEATURES
 
-• Optional number of required total characters
+  - Optional number of required total characters
+  - Optional number of required special characters
+  - Optional number of required digits
 
-• Optional number of required special characters
-
-• Optional number of required digits
-
-USAGE
+# USAGE
 
 See our main README for supported settings and examples.
-
 */
 package main


### PR DESCRIPTION
- update doc.go file to use Go 1.19 package doc comments syntax
  - NOOP on earlier versions
- give crypto/rand import an alias to workaround false-positive
  gosec linter warning