### PR TITLE
Update project to Go 1.19

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -81,5 +81,5 @@ updates:
         versions:
           # Ignore updates from series associated with the latest "stable"
           # Go release and no longer supported Go versions.
-          - ">= 1.18"
-          - "< 1.17"
+          - ">= 1.20"
+          - "< 1.19"

--- a/cmd/tsm-pass/doc.go
+++ b/cmd/tsm-pass/doc.go
@@ -1,0 +1,19 @@
+// Copyright 2020 Adam Chalkley
+//
+// https://github.com/atc0005/tsm-pass
+//
+// Licensed under the MIT License. See LICENSE file in the project root for
+// full license information.
+
+// Generate a random password string compatible with IBM Spectrum
+// Protect (aka, "TSM" or "Tivoli").
+//
+// See our [GitHub repo]:
+//
+//   - to review documentation (including examples)
+//   - for the latest code
+//   - to file an issue or submit improvements for review and potential
+//     inclusion into the project
+//
+// [GitHub repo]: https://github.com/atc0005/tsm-pass
+package main

--- a/cmd/tsm-pass/main.go
+++ b/cmd/tsm-pass/main.go
@@ -5,7 +5,6 @@
 // Licensed under the MIT License. See LICENSE file in the project root for
 // full license information.
 
-// Generate Tivoli-compliant random passwords
 package main
 
 import (

--- a/dependabot/docker/go/Dockerfile
+++ b/dependabot/docker/go/Dockerfile
@@ -14,4 +14,4 @@
 # binaries) to reflect that version of Go.
 
 # https://hub.docker.com/_/golang
-FROM golang:1.17.13
+FROM golang:1.19.0

--- a/go.mod
+++ b/go.mod
@@ -7,4 +7,4 @@
 
 module github.com/atc0005/tsm-pass
 
-go 1.17
+go 1.19


### PR DESCRIPTION
- update go.mod file from Go 1.17 to 1.19
- add separate "package" doc file to match approach used by other
  projects that I maintain
- update "Canary" Dockerfile to reflect current Go 1.19 version
- update Dependabot configuration for Dockerfile to ignore Go releases
  outside of the Go 1.19 release series