### PR TITLE
Fix goconst linting errors

### DIFF
--- a/internal/config/constants.go
+++ b/internal/config/constants.go
@@ -13,6 +13,10 @@ const (
 	myAppURL  string = "https://github.com/atc0005/tsm-pass"
 )
 
+// shorthandFlagSuffix is appended to short flag help text to emphasize that
+// the flag is a shorthand version of a longer flag.
+const shorthandFlagSuffix = " (shorthand)"
+
 // Help text used with flags
 const (
 	versionFlagHelp         string = "Whether to display application version and then immediately exit application."

--- a/internal/config/flags.go
+++ b/internal/config/flags.go
@@ -11,16 +11,16 @@ import "flag"
 
 func (c *Config) handleFlagsConfig() {
 
-	flag.BoolVar(&c.showVersion, "v", defaultDisplayVersionAndExit, versionFlagHelp+" (shorthand)")
+	flag.BoolVar(&c.showVersion, "v", defaultDisplayVersionAndExit, versionFlagHelp+shorthandFlagSuffix)
 	flag.BoolVar(&c.showVersion, "version", defaultDisplayVersionAndExit, versionFlagHelp)
 
-	flag.IntVar(&c.minDigits, "md", defaultMinDigits, minDigitsFlagHelp+" (shorthand)")
+	flag.IntVar(&c.minDigits, "md", defaultMinDigits, minDigitsFlagHelp+shorthandFlagSuffix)
 	flag.IntVar(&c.minDigits, "min-digits", defaultMinDigits, minDigitsFlagHelp)
 
-	flag.IntVar(&c.minSpecialChars, "ms", defaultMinSpecialChars, minSpecialCharsFlagHelp+" (shorthand)")
+	flag.IntVar(&c.minSpecialChars, "ms", defaultMinSpecialChars, minSpecialCharsFlagHelp+shorthandFlagSuffix)
 	flag.IntVar(&c.minSpecialChars, "min-specials", defaultMinSpecialChars, minSpecialCharsFlagHelp)
 
-	flag.IntVar(&c.totalChars, "l", defaultTotalChars, totalCharsFlagHelp+" (shorthand)")
+	flag.IntVar(&c.totalChars, "l", defaultTotalChars, totalCharsFlagHelp+shorthandFlagSuffix)
 	flag.IntVar(&c.totalChars, "length", defaultTotalChars, totalCharsFlagHelp)
 
 	// Allow our function to override the default Help output


### PR DESCRIPTION
Replace literal text with new `shorthandFlagSuffix` config constant.