### PR TITLE
Fix `MD056/table-column-count` linting warning

### DIFF
--- a/README.md
+++ b/README.md
@@ -99,7 +99,7 @@ Passwords can be be composed of these valid characters:
 | `=`        | Equals                                                 |
 | `(`        | Open parenthesis (or open bracket)                     |
 | `)`        | Close parenthesis (or close bracket)                   |
-| `|`        | Vertical bar                                           |
+| `\|`       | Vertical bar                                           |
 | `{`        | Opening brace                                          |
 | `}`        | Closing brace                                          |
 | `[`        | Opening bracket                                        |


### PR DESCRIPTION
Use backslash to escape the pipe symbol to prevent interpreting it as part of the table column syntax.

refs https://stackoverflow.com/questions/17319940