### PR TITLE
Fix errcheck linting errors

### DIFF
--- a/cmd/tsm-pass/main.go
+++ b/cmd/tsm-pass/main.go
@@ -57,7 +57,7 @@ func generatePassword(length int, reqNums int, reqSpecialChars int) (string, err
 	}
 
 	for i := 0; i < reqNums; i++ {
-		// fmt.Fprintln(os.Stderr, i)
+		// _, _ = fmt.Fprintln(os.Stderr, i)
 		val, err := getByte(digits)
 		if err != nil {
 			return "", err
@@ -67,7 +67,7 @@ func generatePassword(length int, reqNums int, reqSpecialChars int) (string, err
 	}
 
 	for i := 0; i < reqSpecialChars; i++ {
-		// fmt.Fprintln(os.Stderr, i)
+		// _, _ = fmt.Fprintln(os.Stderr, i)
 		val, err := getByte(tsmSpecialChars)
 		if err != nil {
 			return "", err
@@ -78,7 +78,7 @@ func generatePassword(length int, reqNums int, reqSpecialChars int) (string, err
 
 	remainingChars := length - reqNums - reqSpecialChars
 	for i := 0; i < remainingChars; i++ {
-		// fmt.Fprintln(os.Stderr, i)
+		// _, _ = fmt.Fprintln(os.Stderr, i)
 		val, err := getByte(allValidChars)
 		if err != nil {
 			return "", err

--- a/internal/config/config.go
+++ b/internal/config/config.go
@@ -47,8 +47,8 @@ type Config struct {
 // Usage is a custom override for the default Help text provided by the flag
 // package. Here we prepend some additional metadata to the existing output.
 var Usage = func() {
-	fmt.Fprintln(flag.CommandLine.Output(), "\n"+Version()+"\n")
-	fmt.Fprintf(flag.CommandLine.Output(), "Usage of %s:\n", os.Args[0])
+	_, _ = fmt.Fprintln(flag.CommandLine.Output(), "\n"+Version()+"\n")
+	_, _ = fmt.Fprintf(flag.CommandLine.Output(), "Usage of %s:\n", os.Args[0])
 	flag.PrintDefaults()
 }
 


### PR DESCRIPTION
Resolve `return value of fmt.Fprintf is not checked`` errors by
explicitly discarding return values (potential error, bytes written)
since we do not need them and the potential for failure (in this
particular use case) is *highly* unlikely.
